### PR TITLE
3 multiple databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mysql_query:
   mysql_db: <mysqldb databasename
 ```
 ## Usage
-The service should be called by passing the query parameter.
+The service should be called by passing the query parameter and optionally the db4query parameter to support multiple databases.
 
 ### Request
 <b>Examples:</b><br>
@@ -65,6 +65,7 @@ The service should be called by passing the query parameter.
 service: mysql_query.query
 data:
   query: select * from contact where phonenumber='1234567890'
+  db4query: privatedb
 
 service: mysql_query.query
 data:
@@ -112,3 +113,17 @@ action:
       target: youraccount@gmail.com
 mode: single
 ```
+## Multiple databases
+The database configured with the mysql_db configuration parameter in configuration.yaml acts as the default database for each query.
+However,the default database can be overrided for each query by providing <b>db4query</b> alongside the query parameter.
+
+Example:
+```text
+service: mysql_query.query
+data:
+  query: select "hello world" from dual
+  db4query: contact
+```
+The query from this example will be executed against the contact database, although the default database specified by the mysql_db configuration parameter may be a complete different database.
+
+

--- a/custom_components/mysql_query/const.py
+++ b/custom_components/mysql_query/const.py
@@ -5,6 +5,7 @@ CONF_MYSQL_DB = "mysql_db"
 CONF_MYSQL_TIMEOUT = "mysql_timeout"
 
 QUERY = "query"
+DB4QUERY = "db4query"
 
 # Defaults
 DEFAULT_MYSQL_TIMEOUT = 10

--- a/custom_components/mysql_query/manifest.json
+++ b/custom_components/mysql_query/manifest.json
@@ -7,5 +7,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/IAsDoubleYou/homeassistant-mysql_query/issues",
     "requirements": ["mysql-connector-python"],
-    "version": "1.0.0"
+    "version": "1.1.0"
 }


### PR DESCRIPTION
The database configured with the mysql_db configuration parameter will act as the default database for each query
When invoking the service, a new parameter DB4QUERY will be available to override the default database for this query
With this approach, the component will be compatible with the previous version, while providing a way to use multiple databases.

Example:

service: mysql_query.query
data:
  query: select "hello world" from dual
  db4query: contact

Solving issue (feature request) originally raised by @GaryK4