### PR TITLE
Modified async_setup to use an async call to stop the log message about blocking call in mysql_query

### DIFF
--- a/custom_components/mysql_query/__init__.py
+++ b/custom_components/mysql_query/__init__.py
@@ -6,6 +6,7 @@ import mysql.connector
 import logging
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
+from functools import partial
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers.typing import ConfigType
 from typing import Final
@@ -88,7 +89,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     try:
         _LOGGER.info(f"Establishing connection with database {mysql_db} at {mysql_host}:{mysql_port}")
-        _cnx = mysql.connector.connect(**connect_kwargs)
+        _cnx = await hass.async_add_executor_job(partial(mysql.connector.connect, **connect_kwargs))
 
     except Exception as e:
            # Log the rror with the full stack trace

--- a/custom_components/mysql_query/services.yaml
+++ b/custom_components/mysql_query/services.yaml
@@ -1,1 +1,20 @@
-# Service ID
+query:
+  name: MySQL Query
+  description: Queries a MySQL Database
+  fields:
+    query:
+      name: Query
+      description: The SELECT or WITH query to execute
+      example: 'SELECT column1, column2 FROM database WHERE column3=value'
+      required: true
+      selector:
+        text:
+          type: text
+    db4query:
+      name: Query Database
+      description: An alternate database to query.
+      example: 'database_name'
+      required: false
+      selector:
+        text:
+          type: text


### PR DESCRIPTION
I was receiving HomeAssistant log messages regarding a blocking call in mysql_query, by adding the import for partial and changing the db call to use hass.async_add_executor_job to call mysql.connector.connectm the logging was removed.
I also updated services.yaml so that the parameters are easier to view in developer tools within HomeAssistant